### PR TITLE
Skip waiting for proxy connections to close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/alpha-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Curl-like CLI for the Alpha client",
   "author": "LifeOmic <development@lifeomic.com>",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,7 @@ const callAlpha = async (config) => {
 };
 
 if (config.proxied) {
-  const server = alphaProxy(config, callAlpha).on('listening', () => {
+  alphaProxy(config, callAlpha).on('listening', () => {
     console.log(`Proxy is listening on port ${config.proxyPort}; Press any key to quit;`);
   });
 
@@ -42,9 +42,7 @@ if (config.proxied) {
     process.stdin.setRawMode(true);
   }
   process.stdin.on('data', () => {
-    server.close(() => {
-      process.exit(0);
-    });
+    process.exit(0);
   });
 } else if (!skipRequest) {
   callAlpha(config).then((result) => {


### PR DESCRIPTION
Small fix to prevent hangs on input if a proxied request is timing out. In this case, there's no real need to wait for the server's connections to complete gracefully.